### PR TITLE
update ACF example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a [Composer](https://getcomposer.org/) plugin offering a way to referenc
 
 ## Examples
 
-### Arbitrary private package
+### Arbitrary private packages
 
 Add the desired private package to the `repositories` field inside `composer.json`. Find more about Composer repositories in the [Composer documentation](https://getcomposer.org/doc/05-repositories.md#repositories). Specify the exact version to install, and use `{%VARIABLE}` placeholders to specify any sensitive tokens in your `.env` file.
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ This is a [Composer](https://getcomposer.org/) plugin offering a way to referenc
 
 ### Arbitrary private package
 
-Add the desired private package to the `repositories` field inside `composer.json`. Find more about Composer repositories in the [Composer documentation](https://getcomposer.org/doc/05-repositories.md#repositories). Replace the version as well as other sensitive tokens by `{%VARIABLE}` placeholders.
+Add the desired private package to the `repositories` field inside `composer.json`. Find more about Composer repositories in the [Composer documentation](https://getcomposer.org/doc/05-repositories.md#repositories). Specify the exact version to install, and use `{%VARIABLE}` placeholders to specify any sensitive tokens in your `.env` file.
 
 ```json
 {
   "type": "package",
   "package": {
     "name": "package-name/package-name",
-    "version": "1.0.0",
+    "version": "REPLACE_WITH_LATEST_PLUGIN_VERSION",
     "dist": {
       "type": "zip",
       "url": "https://example.com/package-name.zip?key={%PACKAGE_KEY}&version={%VERSION}"
@@ -61,7 +61,7 @@ WordPress plugins can be installed using the package type `wordpress-plugin` in 
   "type": "package",
   "package": {
     "name": "advanced-custom-fields/advanced-custom-fields-pro",
-    "version": "5.10.2",
+    "version": "REPLACE_WITH_LATEST_ACF_VERSION",
     "type": "wordpress-plugin",
     "dist": {
       "type": "zip",

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ WordPress plugins can be installed using the package type `wordpress-plugin` in 
   "type": "package",
   "package": {
     "name": "advanced-custom-fields/advanced-custom-fields-pro",
-    "version": "1.2.3",
+    "version": "5.10.2",
     "type": "wordpress-plugin",
     "dist": {
       "type": "zip",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the desired private package to the `repositories` field inside `composer.jso
   "type": "package",
   "package": {
     "name": "package-name/package-name",
-    "version": "REPLACE_WITH_LATEST_PLUGIN_VERSION",
+    "version": "REPLACE_WITH_LATEST_PACKAGE_VERSION",
     "dist": {
       "type": "zip",
       "url": "https://example.com/package-name.zip?key={%PACKAGE_KEY}&version={%VERSION}"


### PR DESCRIPTION
As currently documented with version `1.2.3`, the command `composer require "advanced-custom-fields/advanced-custom-fields-pro:*"` fails.

This brings the version up to something close to current so it doesn’t immediately fail and discourage use of this package.

An alternative might be to use a placeholder instead of `1.2.3` so it’s a bit more obvious that the user needs to set it to a current version.